### PR TITLE
Avoid reallocations in next_gen with step() along with clippy improvements

### DIFF
--- a/src/dudect.rs
+++ b/src/dudect.rs
@@ -65,14 +65,14 @@ where
 
         // Return results when t value is above threshold
         if t >= self.t_threshold {
-            return (t, DudeResult::Ok);
+            (t, DudeResult::Ok)
         }
         // Check if we should give up
         else if self.first_stats.count > self.fail_min_samples && t <= self.t_fail {
-            return (t, DudeResult::Err);
+            (t, DudeResult::Err)
         } else {
             // Neither success nor failure, keep going.
-            return (t, DudeResult::Progress);
+            (t, DudeResult::Progress)
         }
     }
 }

--- a/src/dudect.rs
+++ b/src/dudect.rs
@@ -1,6 +1,4 @@
 use rolling_stats::Stats;
-use statrs::statistics::Mean;
-use statrs::statistics::Variance;
 
 pub enum DudeResult {
     Ok,       // Success

--- a/src/dudect.rs
+++ b/src/dudect.rs
@@ -33,12 +33,12 @@ where
         function: T,
     ) -> Self {
         DudeCT {
-            t_threshold: t_threshold,
-            t_fail: t_fail,
-            fail_min_samples: fail_min_samples,
-            first: first,
-            second: second,
-            function: function,
+            t_threshold,
+            t_fail,
+            fail_min_samples,
+            first,
+            second,
+            function,
             first_stats: Stats::new(),
             second_stats: Stats::new(),
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,8 +33,8 @@ where
 {
   pub fn new(len: usize, function: T) -> Self {
     SideFuzz {
-      len: len,
-      function: function,
+      len,
+      function,
     }
   }
 

--- a/src/optimizer.rs
+++ b/src/optimizer.rs
@@ -55,11 +55,10 @@ where
         let mut scored: Vec<ScoredInputPair> = Vec::with_capacity(self.population.len());
 
         for individual in self.population.iter() {
-            let individual = individual.clone();
             let fitness = (self.fitness)(&individual.first, &individual.second);
             scored.push(ScoredInputPair {
                 score: fitness,
-                pair: individual,
+                pair: individual.clone(),
             });
         }
 
@@ -81,18 +80,7 @@ where
 
     pub fn step(&mut self) {
         // Get fitness of all individuals
-        let mut scored: Vec<ScoredInputPair> = Vec::with_capacity(self.population.len());
-
-        for individual in self.population.drain(..) {
-            let fitness = (self.fitness)(&individual.first, &individual.second);
-            scored.push(ScoredInputPair {
-                score: fitness,
-                pair: individual,
-            });
-        }
-
-        // Sort most fit to least fit
-        scored.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap());
+        let scored = self.scored_population();
 
         // Calculate number to clone and number to breed
         let num_clone: usize = (POPULATION_SIZE as f64 * CLONE_RATIO) as usize;

--- a/src/optimizer.rs
+++ b/src/optimizer.rs
@@ -104,8 +104,8 @@ where
         let mut next_gen: Vec<InputPair> = Vec::with_capacity(self.population.len());
 
         // Clone the top contenders
-        for n in 0..num_clone {
-            next_gen.push(scored[n].pair.clone());
+        for score in scored.iter().take(num_clone) {
+            next_gen.push(score.pair.clone());
         }
 
         // Breed and mutate the rest

--- a/src/optimizer.rs
+++ b/src/optimizer.rs
@@ -75,9 +75,8 @@ where
             sum += val.score;
             sum
         });
-        let average = sum / (scored.len() as f64);
-
-        average
+        
+        sum / (scored.len() as f64)
     }
 
     pub fn step(&mut self) {


### PR DESCRIPTION
This PR just contains some clippy improvements and avoids some reallocations.